### PR TITLE
docs: CLAUDE.md を TOC 化・README.md を OSS 向けに再構成

### DIFF
--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -294,6 +294,72 @@ await eventBus.publish({
 });
 ```
 
+## Edge コンポーネントと MQTT パイプライン
+
+### Edge コンポーネント（Greengrass V2）
+
+Greengrass Core 単一コンテナ内に 2 コンポーネントを統合実行する。
+
+| コンポーネント | 実装 | 役割 |
+|----|----|----|
+| **FrameCapture** | Node.js + ffmpeg | RTSP → 1 fps でフレーム取得 → `/tmp/frame.jpg` → S3 `live-frames/latest.jpg` |
+| **ChewingAnalyzer** | Python 3.9 + OpenCV | `/tmp/frame.jpg` 監視 → 顔検出 + 咀嚼判定 → S3 `live-frames/latest-analyzed.jpg`（BB 付き）→ 状態変化時に MQTT 送信 |
+
+Mac 開発環境では `frame-capture-dev`（独立コンテナ、Docker Compose `--profile dev`）のみが動作し、Greengrass 由来のコンポーネントは使わない（macOS の IPC 制約）。詳細運用手順は [edge/README.md](../../edge/README.md)。
+
+### ChewingAnalyzer 咀嚼判定アルゴリズム
+
+1. **顔検出**: OpenCV Haar Cascade（正面顔、`minSize=60x60`、`FACE_CASCADE_MIN_NEIGHBORS` 可変）
+2. **口領域**: 顔矩形の下部 30%（`MOUTH_ROI_RATIO`）を口領域と仮定
+3. **差分計算**: 前フレームとの口領域ピクセル差分（`cv2.absdiff` → `np.sum`）
+4. **咀嚼判定**: 直近 5 フレーム（`ANALYSIS_FRAME_COUNT`）の平均差分量が閾値（`CHEWING_MOTION_THRESHOLD`、既定 500）超 → chewing
+5. **状態遷移**: `waiting` → `chewing` → `chewing_stopped` → `meal_ended`
+6. **エビデンス**: 状態変化時に BB 付き画像を S3 `evidence/` プレフィックスへアップロード
+
+主要パラメータは管理画面の SystemSettings 経由で MQTT で動的反映される（後述「設定反映フロー」）。
+
+### MQTT トピック規約
+
+| トピック | 方向 | 用途 |
+|----|----|----|
+| `noeatstop/{deviceId}/chewing-state` | Edge → Cloud | 咀嚼状態変化通知 |
+| `noeatstop/{deviceId}/frame-change` | Edge → Cloud | フレーム変化イベント（顔検出/消失/動き/状態変化） |
+| `noeatstop/{deviceId}/settings` | Cloud → Edge | 検出パラメータの動的反映 |
+
+`{deviceId}` は Greengrass Thing Name（既定 `noeatstop-edge-device`）。`IOT_ENDPOINT` は `edge/.env` で設定し、`aws iot describe-endpoint --endpoint-type iot:Data-ATS` で取得する。
+
+### IoT Topic Rule → Lambda → DynamoDB
+
+```
+Edge (Greengrass)
+  ↓ MQTT publish: noeatstop/{deviceId}/chewing-state
+AWS IoT Core (Topic Rule)
+  ↓ select * from 'noeatstop/+/chewing-state'
+Lambda handleChewingState
+  ↓ PutItem with expiresAt (TTL)
+DynamoDB: ChewingStates テーブル
+```
+
+- TTL: `expiresAt` 属性で自動削除。既定 7 日、`chewingStateRetentionDays` 設定で変更可能
+- `frame-change` トピックも同様のパターンで `FrameChangeEvents` テーブルへ
+- Lambda 側は冪等性に注意（同一 messageId の二重受信が起こり得る）
+
+### 設定反映フロー
+
+```
+管理画面 → API Gateway → Lambda → DynamoDB (SystemSettings)
+                                       ↓ Stream / 明示 publish
+                                  Lambda publishSettings
+                                       ↓ MQTT publish
+                              noeatstop/{deviceId}/settings
+                                       ↓
+                              Greengrass コンポーネント
+                                       ↓ ホットリロード
+                              ChewingAnalyzer / FrameCapture
+```
+
+新規パラメータを追加する場合、`MQTT 送信側 Lambda`、`Greengrass 受信側コンポーネント`、`SystemSettings DynamoDB スキーマ` の 3 箇所を同時に更新する必要がある。
+
 ## Data Architecture
 
 ### Database Design Principles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,125 +1,93 @@
-# NoEatToStop System
+# NoEatToStop System - 開発ガイド
 
-子供の食事中の咀嚼動作を監視し、食事が止まったときにテレビの電源を自動制御するスマートシステム。
+子供の食事中の咀嚼動作を監視し、食事停止時にテレビ電源を自動制御するスマートシステム。
 
-## プロジェクト構成
+## 作業開始前のチェック（必読・全エージェント共通）
 
-### 仕様書
-- `.kiro/specs/requirements.md` - 要件定義
-- `.kiro/specs/design.md` - 設計書
-- `.kiro/specs/tasks.md` - 実装タスク
+新しいタスク・Issue 対応・PR 作成に着手する前に、毎回必ず本セクションを再確認する。本プロジェクトは複数の AI エージェント・開発者が並行作業することを想定しており、各自が同じルールに従うことで仕様・規約・運用方針の一貫性を保つ。
 
-### 開発方針（Steering）
-- `.kiro/steering/product.md` - プロダクト概要
-- `.kiro/steering/architecture.md` - アーキテクチャ原則
-- `.kiro/steering/development.md` - 開発ガイド・コーディング指針
-- `.kiro/steering/git.md` - Git ワークフロー・コミット規約
-- `.kiro/steering/structure.md` - ディレクトリ構成・命名規則
-- `.kiro/steering/tech.md` - 技術スタック
-- `.kiro/steering/testing.md` - テスト戦略
-- `.kiro/steering/security.md` - セキュリティ標準
-- `.kiro/steering/environment.md` - 開発環境（Colima/Greengrass）
+1. **本ファイル（CLAUDE.md）を冒頭から再参照** — 仕様駆動開発ルール / 変更時の更新トリガー / 環境戦略 / 重要な設計原則
+2. **対象機能の仕様書を確認** — `.kiro/specs/{requirements.md, design.md, tasks.md}`
+3. **タスクに該当する steering ファイルを確認**:
+   - 新機能・アーキ変更 → [architecture.md](.kiro/steering/architecture.md), [structure.md](.kiro/steering/structure.md)
+   - 技術スタック・依存・環境変数 → [tech.md](.kiro/steering/tech.md), [development.md](.kiro/steering/development.md)
+   - テスト追加・テスト変更 → [testing.md](.kiro/steering/testing.md)
+   - PR 作成・コミット・ブランチ操作 → [git.md](.kiro/steering/git.md)
+   - 開発環境（Colima / Greengrass）→ [environment.md](.kiro/steering/environment.md)
+   - セキュリティ・認証 → [security.md](.kiro/steering/security.md)
+4. **並行作業時は git worktree を使用** — `dev` から作業ブランチを切り、`.worktrees/<branch-name>/` を作成（[git.md](.kiro/steering/git.md) 参照）
+5. **PR は `dev` をベースに作成** — レビュー後に `dev` へマージ、`main` への反映は `dev → main` の PR 経由のみ
 
-## 環境設定
+> 仕様駆動開発の根幹: **仕様 → 設計 → 実装 → ドキュメント整合**。途中でルール確認を省略すると、複数エージェント間でドリフトが発生する。
 
-### 管理方針
+## 仕様書
 
-- **テンプレート（Git 管理対象）**: `.env.local.example`, `edge/.env.example`
-- **実値（Git 管理外）**: `.env.local`, `edge/.env`
-- 各開発者は `.env.local.example` をコピーして `.env.local` を作成し、自分の環境値（AWS アカウント情報・リージョン・Cognito ID 等）を記入する
-- 値の追加・変更が必要になった場合は、**`.env.local.example` のテンプレートも同時に更新**してチームに共有する（実値ファイルはコミット禁止）
+| ファイル | 内容 |
+|---------|------|
+| [.kiro/specs/requirements.md](.kiro/specs/requirements.md) | 要件定義（受入基準付き） |
+| [.kiro/specs/design.md](.kiro/specs/design.md) | 設計書 |
+| [.kiro/specs/tasks.md](.kiro/specs/tasks.md) | 実装タスク |
 
-### 利用フロー
+## 開発ルール（詳細は各ファイル参照）
 
-```bash
-# 初回セットアップ
-cp .env.local.example .env.local
-cp edge/.env.example edge/.env
-# 値を編集
+| ファイル | 内容 |
+|---------|------|
+| [.kiro/steering/product.md](.kiro/steering/product.md) | プロダクト概要・対象ユーザー |
+| [.kiro/steering/architecture.md](.kiro/steering/architecture.md) | アーキテクチャ原則・レイヤー・データモデル・API 設計 |
+| [.kiro/steering/structure.md](.kiro/steering/structure.md) | ディレクトリ構成・命名規則・CDK スタック構成 |
+| [.kiro/steering/tech.md](.kiro/steering/tech.md) | 技術スタック・バージョン・ビルドコマンド |
+| [.kiro/steering/development.md](.kiro/steering/development.md) | 開発ガイド・Lambda パターン・`.env.local` 管理 |
+| [.kiro/steering/testing.md](.kiro/steering/testing.md) | テスト戦略・E2E（Playwright）・カバレッジ目標 |
+| [.kiro/steering/git.md](.kiro/steering/git.md) | Git ワークフロー・Conventional Commits・PR ガイドライン |
+| [.kiro/steering/security.md](.kiro/steering/security.md) | セキュリティ標準・Cognito 認証・IAM 最小権限・PII 取扱い |
+| [.kiro/steering/environment.md](.kiro/steering/environment.md) | 開発環境（Colima / Greengrass）・Mac vs RPi 差異 |
 
-# 開発・デプロイ・E2E テスト前に必ず環境変数として適用
-source .env.local
-```
+## 変更時のドキュメント更新トリガー
 
-- 開発・デプロイ・テストスクリプト実行前に必ず `source .env.local` で環境変数化すること
-- AWS 関連エラー時はまず `.env.local` の値を確認
-- ハードコードされた AWS アカウント ID・リージョン・URL は禁止。必ず環境変数を参照する
-- 詳細: `.kiro/steering/development.md` の「環境設定ファイル」セクション
+実装変更を加えたら、変更種別に応じて以下のドキュメントを必ず同時更新する。
 
-## Edge 環境（RTSP + IoT Greengrass）
+| 変更したもの | 必ず更新するドキュメント |
+|-----------|-------------------|
+| 新 API パラメータ | `specs/requirements.md`（AC 追加）+ `specs/design.md`（パラメータ表）+ `steering/architecture.md` |
+| 新 Lambda エンドポイント | `steering/architecture.md`（エンドポイント表）+ `specs/requirements.md`（Req）+ `specs/design.md`（API） |
+| 新環境変数 | `steering/development.md`（変数一覧）+ `.env.local.example`（テンプレ）+ 必要に応じて `specs/design.md` |
+| 新 Lambda 関数 | `steering/architecture.md` + `steering/structure.md`（依存）+ `specs/design.md` |
+| デプロイ手順・Edge 構成 | `steering/environment.md` または `steering/development.md` + `edge/README.md` |
+| 新テストコマンド | `steering/testing.md` + `package.json` |
+| 依存パッケージ | `steering/tech.md`（バージョン制約も） |
+| Git / PR ルール | `steering/git.md` |
+| バージョン更新 | `package.json` + `steering/product.md` |
 
-- 詳細: `edge/README.md`
-- Edge 環境変数: `edge/.env`（Git管理外）、テンプレート: `edge/.env.example`
-- Docker Compose: `edge/docker-compose.yml`（greengrass-core / mediamtx / frame-capture-dev）
+## 環境戦略
 
-### Mac vs RPi の違い
-- **Mac 開発環境**: frame-capture → S3 パイプラインのみ。Greengrass Core は macOS 上で動作しない（IPC 制限）
-- **RPi 本番環境**: Greengrass Core 単一コンテナ内で FrameCapture + ChewingAnalyzer を統合実行 + IoT Core MQTT 連携
+単一 AWS アカウント内で 3 環境（dev / staging / prod）をスタック名サフィックスで分離。
+開発フロー: `feature/* → dev → main`（dev は統合・検証、main は安定版、すべて PR 経由）
 
-### RTSP 接続パターン
-- **パターン A（MediaMTX 経由）**: `RTSP_URL` 未設定時。ホスト側 ffmpeg でカメラ映像を MediaMTX に配信
-  - Mac: `edge/start-camera.sh`（avfoundation）
-  - RPi: `edge/start-camera-rpi.sh`（v4l2 + mjpeg）
-- **パターン B（IP カメラ直接）**: `RTSP_URL` 設定時。FrameCapture が直接接続。MediaMTX・start-camera スクリプト不要
+- ローカル設定: `.env.local`（Git 管理外）。テンプレ `.env.local.example` をコピーして編集し、`source .env.local` で適用
+- 詳細・全変数表: [steering/development.md](.kiro/steering/development.md) の「環境設定ファイル」セクション
 
-### 起動手順
-- **Mac 開発**: `docker compose up mediamtx --profile dev frame-capture-dev -d --build` → `./start-camera.sh`
-- **RPi 本番（IP カメラ）**: `docker compose up greengrass-core -d --build`（コンテナ1つのみ）
-- **RPi 本番（USB カメラ）**: `docker compose up greengrass-core mediamtx -d --build` → `./start-camera-rpi.sh`
-- **E2E テスト** (RPi のみ): `./edge/e2e-test.sh`（12項目: GG稼働・HEALTHY・MQTT・S3読書・GGログ・FrameCapture・S3フレーム・ChewingAnalyzer・初期化・MQTT→DynamoDB結合・MQTT送信ログ）
+## 重要な設計原則
 
-### Greengrass コンポーネント
-- **FrameCapture** (Node.js): RTSP → ffmpeg → `/tmp/frame.jpg` → S3 `live-frames/latest.jpg`
-- **ChewingAnalyzer** (Python + OpenCV): `/tmp/frame.jpg` 監視 → 顔検出(Haar Cascade) → 口領域差分 → 咀嚼判定 → BB付き画像を S3 `live-frames/latest-analyzed.jpg` にアップロード → 状態変化時に MQTT 送信
+1. **仕様駆動開発**: `tasks.md` の AC を満たすテスト・実装を行い、完了時にチェックボックスを `[x]` に更新
+2. **IAM 最小権限**: Lambda は必要なリソース ARN だけに権限付与（ワイルドカード禁止）
+3. **環境変数で参照**: AWS アカウント ID・リージョン・URL は `.env.local` 経由。ハードコード禁止
+4. **PII 不在ログ**: 構造化ログには個人情報を含めない（詳細 [security.md](.kiro/steering/security.md)）
+5. **Edge → Cloud 認証**: Greengrass は IoT Core 証明書、フロントは Cognito PKCE
+6. **言語**: ドキュメント・コメント・チャット応答は日本語（コードの識別子は英語）
+7. **パッケージマネージャー**: npm（pnpm は使わない）
+8. **作業ディレクトリ**: 一時ファイルは `./working/`（Git 管理外）
 
-### MQTT → DynamoDB パイプライン
-- **トピック**: `noeatstop/{deviceId}/chewing-state`
-- **IoT Topic Rule** → Lambda `handleChewingState` → DynamoDB `ChewingStates` テーブル
-- **TTL**: `expiresAt` 属性で自動削除（デフォルト7日、`chewingStateRetentionDays` 設定で変更可能）
-- **IOT_ENDPOINT**: `edge/.env` に設定。`aws iot describe-endpoint --endpoint-type iot:Data-ATS` で取得
+## コミット
 
-### ChewingAnalyzer 咀嚼判定ロジック
-1. **顔検出**: OpenCV Haar Cascade（正面顔、minSize=60x60）
-2. **口領域**: 顔矩形の下部 30%（`MOUTH_ROI_RATIO`）を口領域と仮定
-3. **差分計算**: 前フレームとの口領域ピクセル差分量（`cv2.absdiff` → `np.sum`）
-4. **咀嚼判定**: 直近5フレーム（`ANALYSIS_FRAME_COUNT`）の平均差分量が閾値（`CHEWING_MOTION_THRESHOLD=500`）超 → chewing
-5. **状態**: chewing / chewing_stopped / meal_ended / waiting
-6. **エビデンス**: 状態変化時にBB付き画像を S3 `evidence/` にアップロード
+- 形式: `<type>(<scope>): <内容>`（例: `feat(api): エビデンス取得エンドポイント追加`）
+- 本文は日本語で「なぜ」を記述
+- 詳細: [steering/git.md](.kiro/steering/git.md)
 
-## 認証（Cognito）
-
-- 管理画面は Amazon Cognito User Pool + PKCE Authorization Code Flow で保護
-- セルフサインアップ無効。ユーザーは管理者が AWS CLI で招待
-- CDK デプロイ時に `UserPoolId`, `UserPoolClientId`, `CognitoDomainName` が outputs に出力される
-- フロントエンドビルド時に `.env.local` の `VITE_COGNITO_*` 環境変数が必要:
-  - `VITE_COGNITO_DOMAIN` — Cognito Managed Login ドメイン
-  - `VITE_COGNITO_CLIENT_ID` — User Pool App Client ID
-  - `VITE_COGNITO_REDIRECT_URI` — `/callback` パスを含む CloudFront URL
-  - `VITE_COGNITO_LOGOUT_URI` — CloudFront ルート URL
-  - `COGNITO_USER_POOL_ID` — ユーザー管理用（フロントエンドでは不使用）
-- ユーザー管理: `aws cognito-idp admin-create-user` + `admin-set-user-password --permanent`
-- 認証関連ファイル:
-  - `frontend/src/services/authService.ts` — PKCE 生成、OAuth フロー、トークン管理
-  - `frontend/src/stores/authStore.ts` — Pinia 認証状態ストア
-  - `frontend/src/router/index.ts` — beforeEach 認証ガード
-  - `frontend/src/components/AuthCallback.vue` — OAuth callback
-  - `lib/no-eat-to-stop-stack.ts` — Cognito User Pool, App Client, Authorizer (CDK)
-
-## 開発ルール
-
-- **言語**: ドキュメント・コメント・チャット応答は日本語
-- **パッケージマネージャー**: npm（pnpmではない）
-- **作業ディレクトリ**: 一時ファイル・中間データは `./working/` に配置
-- **Git ブランチ**: `dev` が開発マージ用。機能ブランチは `dev` から作成し、e2eテストPASS後に `dev` へマージ
-- **Git 管理外**: `.claude/`, `.mcp.json`, `.env.local`, `working/`, credentials系ファイル
-- **環境設定**: AWS認証・リージョン等は `.env.local` から読み込む。エラー時はまず `.env.local` の値を確認すること
-
-## コマンド
+## デプロイ
 
 ```bash
-npm run build          # TypeScript ビルド
-npm run test           # 全テスト実行
-npm run test:unit      # ユニットテスト
-npm run deploy         # CDK デプロイ
-npm run deploy:all     # 全体デプロイ（VITE_COGNITO_* 環境変数を .env.local に設定してから実行）
+source .env.local         # 環境変数を適用
+npm run deploy:all        # CDK インフラ + フロントエンド
 ```
+
+段階デプロイ・Edge デプロイは [steering/development.md](.kiro/steering/development.md) および [steering/environment.md](.kiro/steering/environment.md) を参照。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,28 @@
 
 子供の食事中の咀嚼動作を監視し、食事が止まったときにテレビの電源を自動制御するスマートシステム。
 
-## アーキテクチャ概要
+## 概要
+
+エッジデバイス（Raspberry Pi）に接続したカメラ映像から子供の咀嚼動作を検出し、一定時間食事が止まったらクラウドからテレビ電源を制御することで、保護者の食事中の声かけ負担を軽減する。
+
+| 機能 | 概要 | 動作場所 |
+|------|------|---------|
+| 映像キャプチャ | RTSP / USB カメラから 1 fps でフレーム取得 | Edge（Greengrass） |
+| 咀嚼検出 | OpenCV Haar Cascade で顔→口領域の動きを判定 | Edge（Greengrass） |
+| 状態同期 | 検出結果を IoT Core MQTT 経由でクラウド DynamoDB に記録 | Cloud |
+| 管理画面 | リアルタイム映像・履歴・エビデンス画像・設定変更 | Cloud（CloudFront） |
+| TV 制御 | 食事停止時に Smart TV API / Alexa 経由で電源 OFF | Cloud → 自宅機器 |
+
+## 主な特徴
+
+- **エッジ完結型咀嚼検出**: 顔→口領域→ピクセル差分による軽量アルゴリズム。クラウド推論不要
+- **MQTT パイプライン**: Edge → IoT Core Topic Rule → Lambda → DynamoDB（TTL 自動削除付き）
+- **PKCE 認証**: 管理画面は Amazon Cognito Managed Login + PKCE Authorization Code Flow で保護
+- **エビデンス記録**: 状態変化時にバウンディングボックス付き画像を S3 に保存。管理画面で振り返り可能
+- **設定の動的反映**: 管理画面から閾値や検出パラメータを変更すると Edge 側へ MQTT 経由で反映
+- **Mac / RPi 両対応**: Mac はパイプライン開発用（frame-capture のみ）、RPi は本番（Greengrass フル稼働）
+
+## アーキテクチャ
 
 ### Mac 開発環境
 
@@ -10,92 +31,77 @@
 
 ```
 Mac Camera (avfoundation)
-  ↓ ffmpeg (ホスト側)
-MediaMTX (Docker, RTSP サーバー)
+  ↓ ffmpeg
+MediaMTX (Docker, RTSP)
   ↓ RTSP
-frame-capture (Docker) ── ffmpeg で 1 フレーム取得 ──→ S3 (live-frames/latest.jpg)
-                                                          ↓
-                                              Lambda (presigned URL)
-                                                          ↓
-                                              管理画面 (Vue.js / CloudFront)
+frame-capture (Docker) → S3 (live-frames/latest.jpg)
+                            ↓
+                    Lambda (presigned URL)
+                            ↓
+                  管理画面 (Vue.js / CloudFront)
 ```
-
-**用途**: フレームキャプチャ → S3 → 管理画面表示のパイプライン開発・動作確認
 
 ### Raspberry Pi 本番環境
 
-Greengrass Core 単一コンテナ内で FrameCapture + ChewingAnalyzer を統合実行し、IoT Core (MQTT) でクラウドと双方向通信する。
+Greengrass Core 単一コンテナ内で FrameCapture + ChewingAnalyzer を統合実行、IoT Core (MQTT) でクラウドと双方向通信。
 
 ```
-IP Camera (RTSP) または USB Camera
+IP Camera (RTSP) or USB Camera
   ↓ RTSP（直接 or MediaMTX 経由）
 Greengrass Core (Docker)
-  ├── FrameCapture ── ffmpeg で 1 フレーム取得 ──→ S3 (live-frames/latest.jpg)
-  │        └── /tmp/frame.jpg
-  ├── ChewingAnalyzer ── 顔検出 + 咀嚼判定 ──→ S3 (live-frames/latest-analyzed.jpg)
-  │        └── OpenCV Haar Cascade → 口領域差分 → 状態判定
-  │                                                     ↓
-  └── IoT Core MQTT ←──→ AWS IoT Core           Lambda (presigned URL)
-                                                        ↓
-                                              管理画面 (Vue.js / CloudFront)
-                                              ├── 生フレーム表示
-                                              └── 検出BB付きフレーム表示（切替可）
+  ├── FrameCapture        → /tmp/frame.jpg → S3 (live-frames/latest.jpg)
+  ├── ChewingAnalyzer     → 顔検出 + 咀嚼判定 → S3 (latest-analyzed) + MQTT
+  └── IoT Core MQTT ←──→ AWS IoT Core → Lambda → DynamoDB
+                                              ↓
+                                    管理画面 (Vue.js / CloudFront)
 ```
-
-**用途**: 本番稼働。映像キャプチャ + 咀嚼検出 + IoT Greengrass による Edge-Cloud 連携（単一コンテナ）
 
 ### Mac と RPi の主な違い
 
-| 項目 | Mac 開発環境 | Raspberry Pi 本番環境 |
-|------|-------------|---------------------|
-| **目的** | パイプライン開発・UI 動作確認 | 本番稼働 |
-| **Docker コンテナ** | mediamtx + frame-capture-dev | greengrass-core（FrameCapture 統合） |
-| **Greengrass Core** | 不使用 | FrameCapture + ChewingAnalyzer 統合 + IoT Core MQTT |
-| **カメラドライバ** | avfoundation (Mac 内蔵カメラ) | v4l2 (USB) または RTSP (IP カメラ) |
-| **RTSP 取得** | 常に MediaMTX 経由 | MediaMTX 経由 or IP カメラ直接接続 |
-| **Docker ランタイム** | Colima (または Docker Desktop) | Docker Engine |
-| **カメラ配信スクリプト** | `start-camera.sh` | `start-camera-rpi.sh` (USB) / 不要 (IP カメラ) |
-| **E2E テスト** | ― | `e2e-test.sh`（10項目: GG + IoT Core + S3 + ChewingAnalyzer 検証） |
-| **OS / Arch** | macOS (x86_64 / arm64) | Raspberry Pi OS 64-bit (aarch64) |
+| 項目 | Mac 開発 | RPi 本番 |
+|------|----------|----------|
+| 目的 | パイプライン開発・UI 動作確認 | 本番稼働 |
+| Greengrass Core | 不使用（macOS IPC 制限） | 統合実行 |
+| カメラドライバ | avfoundation | v4l2 (USB) / RTSP (IP) |
+| Docker ランタイム | Colima 推奨 | Docker Engine |
+| カメラ配信 | `edge/start-camera.sh` | `edge/start-camera-rpi.sh` または IP カメラ直接 |
+| E2E テスト | Playwright（フロント） | `edge/e2e-test.sh`（10 項目） |
+
+詳細は [.kiro/steering/environment.md](.kiro/steering/environment.md) と [edge/README.md](edge/README.md) を参照。
 
 ## 技術スタック
 
-- **言語**: TypeScript
-- **IaC**: AWS CDK (Cloud Development Kit)
-- **ランタイム**: Node.js (ES2020 target)
-- **フロントエンド**: Vue.js v3 + Tailwind CSS
-- **データベース**: Amazon DynamoDB
-- **映像処理**: Edge OpenCV (Haar Cascade 顔検出 + 咀嚼判定) + Amazon Bedrock (将来)
-- **Edge**: AWS IoT Greengrass V2 (Docker、Node.js 22 + Python 3.9 + OpenCV + ffmpeg 統合)
-- **認証**: Amazon Cognito (User Pool + Managed Login + PKCE Authorization Code Flow)
-- **CDN**: Amazon CloudFront（SPA 配信 + HTTPS）
-- **Docker ランタイム**: Colima (Mac) / Docker Engine (RPi)
+- 言語: TypeScript（Cloud）、Node.js + Python 3.9（Edge）
+- IaC: AWS CDK
+- フロントエンド: Vue.js 3 + Tailwind CSS + Pinia
+- データベース: Amazon DynamoDB
+- 映像処理: OpenCV Haar Cascade（Edge）、Amazon Bedrock（将来）
+- Edge: AWS IoT Greengrass V2 + ffmpeg + OpenCV（Docker）
+- 認証: Amazon Cognito（User Pool + Managed Login + PKCE）
+- CDN: Amazon CloudFront
+
+バージョン・全依存リストは [.kiro/steering/tech.md](.kiro/steering/tech.md) を参照。
 
 ## 前提条件
 
 ### 共通
+- Node.js v18 以上
+- npm（pnpm は不可）
+- AWS CLI v2 + AWS CDK
+- Docker CLI + Docker Compose V2
 
-- **Node.js**: v18 以上
-- **npm**: パッケージマネージャー
-- **AWS CLI v2**: AWS サービス連携
-- **AWS CDK**: インフラデプロイ
-- **Docker CLI + Docker Compose V2**: コンテナ操作
+### Mac 開発環境
+- Colima 推奨（4 CPU / 8 GB 以上）: `brew install colima docker docker-compose`
+- ffmpeg: `brew install ffmpeg`
 
-### Mac 開発環境のみ
+### Raspberry Pi 本番環境
+- Raspberry Pi OS 64-bit (aarch64)
+- Docker Engine: `curl -fsSL https://get.docker.com | sh`
+- USB カメラ または IP カメラ（RTSP 対応）
 
-- **Colima** (推奨) または Docker Desktop: `brew install colima docker docker-compose`
-- **ffmpeg**: `brew install ffmpeg`（カメラ → MediaMTX 配信用）
-
-### Raspberry Pi 本番環境のみ
-
-- **Raspberry Pi OS (64-bit)**: aarch64 必須
-- **Docker Engine**: `curl -fsSL https://get.docker.com | sh`
-- **ffmpeg**: `sudo apt install -y ffmpeg`（USB カメラ使用時のみ）
-- **USB カメラ** または **IP カメラ (RTSP 対応)**
+詳細は [.kiro/steering/environment.md](.kiro/steering/environment.md) を参照。
 
 ## クイックスタート
-
-Edge 環境の詳細は [Edge README](edge/README.md) を参照。
 
 ```bash
 # 1. Clone & install
@@ -103,390 +109,111 @@ git clone <repository-url>
 cd NoEatToStop
 npm install
 
-# 2. 環境変数を設定
-cp .env.local.example .env.local   # AWS 認証情報
-cp edge/.env.example edge/.env     # Edge 環境変数（VIDEO_BUCKET, AWS 認証 等）
+# 2. 環境変数を設定（テンプレからコピーして値を記入）
+cp .env.local.example .env.local
+cp edge/.env.example edge/.env
+# エディタで値を編集してから:
+source .env.local
 
-# 3-a. Mac 開発環境
+# 3. インフラ + フロントエンドをデプロイ
+npm run deploy:all
+
+# 4-a. Mac 開発: frame-capture パイプラインを起動
 colima start --cpu 4 --memory 8
 cd edge
 docker compose --profile dev up mediamtx frame-capture-dev -d --build
-./start-camera.sh   # 別ターミナルで実行（Ctrl+C で停止）
+./start-camera.sh   # 別ターミナルで実行
 
-# 3-b. RPi 本番環境（IP カメラ）— コンテナ1つのみ
+# 4-b. RPi 本番（IP カメラ）
 cd edge
 # edge/.env に RTSP_URL=rtsp://user:pass@<IP>:<port>/stream を設定
 docker compose up greengrass-core -d --build
 
-# 3-c. RPi 本番環境（USB カメラ）
+# 4-c. RPi 本番（USB カメラ）
 cd edge
 docker compose up greengrass-core mediamtx -d --build
-./start-camera-rpi.sh   # 別ターミナルで実行（Ctrl+C で停止）
+./start-camera-rpi.sh
 ```
+
+開発コマンド一覧は [.kiro/steering/development.md](.kiro/steering/development.md) を参照。
 
 ## 認証（Cognito）
 
 管理画面は Amazon Cognito User Pool で保護されている。セルフサインアップは無効で、管理者が AWS CLI でユーザーを招待する。
 
-### ログインフロー
-
-1. CloudFront URL にアクセス → 未認証の場合 Cognito Managed Login にリダイレクト
-2. メール / パスワードでログイン
-3. `/callback` に認可コード付きでリダイレクト → PKCE でトークン交換
-4. ID Token を `localStorage` に保存、API リクエスト時に Bearer ヘッダーとして自動付与
-5. API Gateway の CognitoUserPoolsAuthorizer がトークンを検証
-6. トークン期限切れ時は refresh_token で自動更新、失敗時はログアウト
-
-### 初回ユーザー作成
-
-CDK デプロイ後、`.env.local` の設定値を使ってユーザーを作成する:
-
 ```bash
 source .env.local
-
-# ユーザー作成（セルフサインアップは無効）
 aws cognito-idp admin-create-user \
   --user-pool-id "$COGNITO_USER_POOL_ID" \
   --username user@example.com \
   --user-attributes Name=email,Value=user@example.com Name=email_verified,Value=true \
   --temporary-password 'TempPass123!' \
   --message-action SUPPRESS
-
-# パスワードを永続化（初回ログイン時の強制変更をスキップ）
 aws cognito-idp admin-set-user-password \
   --user-pool-id "$COGNITO_USER_POOL_ID" \
   --username user@example.com \
-  --password 'YourPassword123!' \
-  --permanent
+  --password 'YourPassword123!' --permanent
 ```
 
-### 認証関連の環境変数
-
-フロントエンドビルド時に以下の `VITE_COGNITO_*` 変数が必要。`.env.local` に設定すること:
-
-```bash
-# Cognito 設定（CDK デプロイ後に出力される値を設定）
-COGNITO_USER_POOL_ID=ap-northeast-1_xxxxxxxxx
-VITE_COGNITO_DOMAIN=noeatstop-{stage}.auth.{region}.amazoncognito.com
-VITE_COGNITO_CLIENT_ID=<UserPoolClientId>
-VITE_COGNITO_REDIRECT_URI=https://<cloudfront-domain>/callback
-VITE_COGNITO_LOGOUT_URI=https://<cloudfront-domain>/
-```
-
-CDK デプロイ後の Output（`UserPoolId`, `UserPoolClientId`, `CognitoDomainName`）から値を取得できる。
-
-詳細は [設計書](.kiro/specs/design.md) の「認証アーキテクチャ」および [セキュリティ標準](.kiro/steering/security.md) を参照。
-
-## Project Structure
-
-```
-no-eat-to-stop-system/
-├── .env.local              # Environment variables (git excluded)
-├── .kiro/                  # Kiro IDE configuration and steering rules
-│   ├── specs/              # Specifications (requirements.md, design.md, tasks.md)
-│   └── steering/           # Development guidelines and policies
-├── PRFAQ.md               # Product requirements and FAQ (Japanese)
-├── bin/                   # CDK application entry points
-├── lib/                   # CDK stack definitions and constructs
-│   ├── models/            # TypeScript interfaces and data models
-│   ├── repositories/      # DynamoDB data access layer
-│   ├── services/          # Business logic services
-│   └── lambda/            # Lambda function implementations
-├── edge/                  # Edge デバイス（RTSP + IoT Greengrass）
-│   ├── docker-compose.yml # greengrass-core / mediamtx
-│   ├── greengrass/        # Greengrass Core Docker ビルド（FrameCapture 統合）
-│   ├── frame-capture/     # Mac 開発用 frame-capture（profiles: dev）
-│   ├── start-camera.sh    # Mac カメラ → MediaMTX 配信
-│   ├── start-camera-rpi.sh# RPi USB カメラ → MediaMTX 配信
-│   ├── e2e-test.sh        # Edge E2E テスト
-│   ├── .env               # Edge 環境変数 (git excluded)
-│   └── .env.example       # Edge 環境変数テンプレート
-├── docs/                  # User guides and documentation
-├── scripts/               # Deployment and setup scripts
-├── working/               # Temporary files (git excluded)
-├── package.json           # Node.js dependencies and scripts
-└── tsconfig.json          # TypeScript compiler configuration
-```
-
-## System Components
-
-### Infrastructure Layer (AWS CDK)
-- **S3 Buckets**: Video storage with 1-day lifecycle, judgment data storage, web app hosting
-- **DynamoDB Tables**: MealSessions, EatingStates, SystemSettings, ChewingStates, TVControlEvents, FrameHistory, Labels
-- **Lambda Functions**: API handlers (14個), IoT Topic Rule handlers, S3 Event handler
-- **API Gateway**: RESTful API for frontend integration（全エンドポイント Cognito Authorizer で保護）
-- **CloudFront**: CDN for web application delivery（SPA フォールバック対応）
-- **Cognito User Pool**: 管理画面認証（PKCE Authorization Code Flow、Managed Login）
-- **IoT Core**: MQTT トピックルール → Lambda → DynamoDB パイプライン
-- **IAM Roles**: Least-privilege access for edge devices and Lambda functions
-
-### Edge Layer (`edge/`)
-- **Greengrass Core** (RPi): FrameCapture + ChewingAnalyzer を統合した単一コンテナ。Node.js 22 + ffmpeg でフレームキャプチャ、Python 3.9 + OpenCV で顔検出・咀嚼判定 + IoT Core MQTT 通信
-- **MediaMTX**: RTSP リレーサーバー。USB カメラ / Mac カメラ使用時のみ必要
-- **frame-capture-dev** (Mac 開発のみ): Greengrass が動作しない Mac 用の独立コンテナ（`--profile dev`）
-- **AI Integration**: Amazon Bedrock (Claude) による咀嚼行動分析（クラウド側 Lambda で実行）
-
-### Frontend Layer (Vue.js)
-- **Dashboard**: Real-time meal session monitoring
-- **LiveVideo**: Video feed display with configurable update intervals
-- **SystemSettings**: Comprehensive configuration interface
-- **EmergencyControl**: Manual TV control override
-- **TVControlStatus**: TV control request monitoring and status display
-
-## Configuration Parameters
-
-The system supports comprehensive runtime configuration through the SystemSettings DynamoDB table and management interface:
-
-### Basic Settings
-- **pauseThreshold**: Motion stop threshold (default: 10 seconds)
-- **confidenceThreshold**: AI confidence threshold (default: 80%)
-- **videoBufferDuration**: Video buffer time (default: 10 seconds)
-- **analysisVideoDuration**: Analysis video duration (default: 20 seconds)
-- **videoRetentionDays**: Video retention period (default: 1 day)
-
-### Video Settings
-- **videoResolution**: Camera resolution (default: 640x360)
-- **videoFrameRate**: Frame rate (default: 30fps)
-- **liveVideoUpdateInterval**: Real-time video update interval (default: 3 seconds)
-
-### Recognition Settings
-- **faceDetectionThreshold**: Face recognition threshold
-- **mouthDetectionThreshold**: Mouth position recognition threshold
-- **chewingDetectionThreshold**: Chewing detection threshold
-
-### Target Settings
-- **childCount**: Number of children to monitor
-- **excludeAdults**: Adult detection exclusion flag
-
-### Control Settings
-- **tvControlMethod**: 'smart_tv_api' or 'alexa_voice'
-- **tvControlRetryCount**: Retry count (default: 1)
-- **tvControlRetryInterval**: Retry interval (default: 3 seconds)
+ログインフロー（PKCE Authorization Code Flow）と必要な `VITE_COGNITO_*` 環境変数の詳細は [.kiro/steering/security.md](.kiro/steering/security.md) を参照。
 
-## AWS Resources
+## システム構成
 
-The CDK stack creates the following AWS resources:
+### Infrastructure（AWS CDK）
+- S3 / DynamoDB（MealSessions / EatingStates / SystemSettings / ChewingStates / TVControlEvents / FrameHistory / Labels）
+- Lambda（API ハンドラ + IoT Topic Rule ハンドラ + S3 Event ハンドラ）
+- API Gateway（全エンドポイント Cognito Authorizer 適用）
+- CloudFront（SPA 配信、404 → index.html フォールバック）
+- Cognito User Pool（PKCE）
+- IoT Core（Things / Policies / Topic Rules / Certificates）
 
-- **S3 Buckets**:
-  - Video storage with 1-day lifecycle policy（live-frames, evidence, frames, daily）
-  - Web app hosting with CloudFront distribution
-- **DynamoDB Tables**:
-  - MealSessions, EatingStates, SystemSettings
-  - ChewingStates, TVControlEvents, FrameHistory, Labels（TTL 自動削除）
-- **Cognito**: User Pool, App Client (PKCE), Managed Login Domain, CognitoUserPoolsAuthorizer
-- **Lambda Functions**: API handlers (14個), IoT Topic Rule handlers, S3 Event handler
-- **API Gateway**: RESTful API endpoints（全メソッド Cognito Authorizer 適用）
-- **CloudFront Distribution**: Web application CDN（SPA 404→index.html フォールバック）
-- **IAM Roles**: Edge device role, Lambda execution roles
-- **IoT Core Resources**: Things, Thing Groups, Certificates, Policies, Topic Rules
+### Edge
+- Greengrass Core: FrameCapture（Node.js + ffmpeg）+ ChewingAnalyzer（Python + OpenCV）
+- MediaMTX: RTSP リレー（USB / Mac カメラ使用時のみ）
 
-## Development Commands
+### Frontend（Vue.js + Tailwind）
+- ダッシュボード / ライブ映像 / 食事履歴 / 咀嚼状態 / エビデンス / 設定 / 緊急制御 / TV 制御 / エラー分析
 
-### Colima 管理 (Mac のみ)
+ディレクトリ構造・スタック構成の詳細は [.kiro/steering/structure.md](.kiro/steering/structure.md) を参照。
 
-```bash
-colima start --cpu 4 --memory 8   # 起動
-colima stop                        # 停止
-colima status                      # 状態確認
-colima delete                      # 完全リセット
-```
+## 設定パラメータ
 
-### Edge コンテナ管理
+管理画面の SystemSettings から動的に変更できる主要パラメータ:
 
-```bash
-cd edge
+- 食事停止判定: `pauseThreshold`（既定 10s）、`chewingDetectionThreshold`
+- 映像: `videoResolution`（既定 640x360）、`videoFrameRate`、`liveVideoUpdateInterval`
+- AI: `confidenceThreshold`（既定 80%）
+- 対象: `childCount`、`excludeAdults`
+- 制御: `tvControlMethod`（`smart_tv_api` / `alexa_voice`）、`tvControlRetryCount`、`tvControlRetryInterval`
+- データ保持: `videoRetentionDays`（既定 1 日）
 
-# RPi: Greengrass Core 起動（FrameCapture 統合）
-docker compose up greengrass-core -d --build
+全パラメータ・既定値・データモデルは [.kiro/specs/design.md](.kiro/specs/design.md) と [.kiro/steering/architecture.md](.kiro/steering/architecture.md) を参照。
 
-# RPi: 全サービス停止
-docker compose down
+## トラブルシューティング
 
-# Greengrass Core のログ確認（FrameCapture ログも含む）
-docker logs -f noeatstop-gg-core
+- **Docker daemon に接続できない** → `docker context use colima` で Colima にスイッチ
+- **Colima が起動しない** → `colima delete && colima start --cpu 4 --memory 8 --disk 50`
+- **Architecture mismatch**（Apple Silicon）→ `colima delete && colima start --arch aarch64 --cpu 4 --memory 8`
+- **AWS 認証エラー** → `.env.local` のリージョン / プロファイル設定を確認、`source .env.local` を再実行
+- **Edge / Greengrass 関連** → [edge/README.md](edge/README.md) のトラブルシューティング、または [.kiro/steering/environment.md](.kiro/steering/environment.md) を参照
 
-# コンテナ内でコマンド実行
-docker exec -it noeatstop-gg-core sh
+## 貢献
 
-# コンテナ再起動
-docker compose restart greengrass-core
-```
+1. 関連 issue を確認、または新規 issue を起票
+2. `dev` から `issue/<番号>/<topic>` ブランチを作成
+3. 変更を実装、テスト追加・更新
+4. PR を作成（base: `dev`）
+5. レビュー後にマージ。`main` への反映は `dev → main` の PR 経由のみ
 
-### TypeScript Build
+ブランチ命名・コミット規約は [.kiro/steering/git.md](.kiro/steering/git.md) を参照。
 
-```bash
-# Build TypeScript
-npm run build
+## ドキュメント
 
-# Watch mode for development
-npm run watch
+- [Installation Guide](docs/INSTALLATION.md)
+- [User Manual](docs/USER_MANUAL.md)
+- [Docker Development Guide](docs/guides/DOCKER_DEVELOPMENT_GUIDE.md)
+- [Edge README](edge/README.md)
 
-# Run tests
-npm run test
-```
+仕様書: [requirements](.kiro/specs/requirements.md) / [design](.kiro/specs/design.md) / [tasks](.kiro/specs/tasks.md)
 
-### CDK Deployment
-
-```bash
-# Deploy infrastructure only
-npm run deploy
-
-# Deploy frontend only
-npm run deploy:frontend
-
-# Deploy both infrastructure and frontend
-npm run deploy:all
-
-# Destroy infrastructure
-npm run destroy
-
-# Synthesize CDK template
-npm run synth
-```
-
-## Deployment
-
-### Infrastructure Deployment
-
-```bash
-# Deploy AWS infrastructure (S3, CloudFront, DynamoDB, Lambda, API Gateway, etc.)
-npm run deploy
-```
-
-The CDK deployment will:
-- Create all AWS resources defined in the stack
-- Set up IAM roles and permissions
-- Configure DynamoDB tables with GSI
-- Deploy Lambda functions
-- Create API Gateway endpoints
-- Set up CloudFront distribution
-
-### Frontend Deployment
-
-```bash
-# Build and deploy Vue.js app to S3/CloudFront
-npm run deploy:frontend
-```
-
-The frontend deployment script will:
-- Automatically retrieve the S3 bucket name and API Gateway URL from CloudFormation
-- Update the frontend environment variables with the correct API URL
-- Build the Vue.js application
-- Upload all files to S3
-- Invalidate CloudFront cache
-
-### Complete Deployment
-
-```bash
-# Deploy both infrastructure and frontend in one command
-npm run deploy:all
-```
-
-After deployment, the web application will be accessible via the CloudFront URL shown in the output.
-
-## 開発環境の注意事項
-
-### Mac と RPi の開発スコープ
-
-- **Mac 開発環境**: frame-capture-dev コンテナで S3 パイプラインの開発・UI 動作確認。Greengrass Core は Mac 上では動作しない（IPC の macOS 制限のため）
-- **Raspberry Pi**: 本番環境。Greengrass Core 単一コンテナ内で FrameCapture + IoT Core MQTT のフルスタックが稼働
-- **Greengrass コンポーネントのテスト**: RPi 実機 または EC2 (Linux) で実施すること
-
-## Error Handling
-
-The system implements comprehensive error handling across all layers:
-
-- **Camera failure**: System enters safe state, no TV control actions
-- **Network disconnection**: Edge processing continues locally, syncs when reconnected
-- **AI/Recognition errors**: Falls back to safe state (no control), logs for analysis
-- **TV control failure**: Retry mechanism with configurable attempts and intervals
-- **DynamoDB errors**: Exponential backoff retry with error logging
-- **S3 upload failures**: Local buffering with retry queue
-
-## Troubleshooting
-
-### Colima (Mac のみ)
-
-**Docker command fails with "Cannot connect to the Docker daemon"**:
-```bash
-# Check Docker context
-docker context ls
-
-# Switch to Colima context
-docker context use colima
-
-# Verify Colima is running
-colima status
-
-# Start Colima if not running
-colima start
-```
-
-**Colima won't start**:
-```bash
-# Check logs
-colima logs
-
-# Complete reset
-colima delete
-colima start --cpu 4 --memory 8 --disk 50
-```
-
-**Volume mount not working**:
-```bash
-# SSH into Colima VM to check mounts
-colima ssh
-ls -la /Users/$(whoami)/
-
-# If home directory is not visible, restart Colima
-exit
-colima restart
-```
-
-**Architecture mismatch errors**:
-```bash
-# Check current architecture
-colima status | grep Arch
-
-# For x86_64 devices (Intel)
-colima delete
-colima start --arch x86_64 --cpu 4 --memory 8
-
-# For arm64 devices (Apple Silicon)
-colima delete
-colima start --arch aarch64 --cpu 4 --memory 8
-```
-
-### Edge / Greengrass トラブルシューティング
-
-Edge 固有の問題（Greengrass、frame-capture、カメラ）については [Edge README](edge/README.md) のトラブルシューティングセクションを参照。
-
-## Security Features
-
-- **IAM Least-Privilege Access**: Minimal required permissions for each component
-- **Data Encryption**: 
-  - S3 server-side encryption (SSE-S3)
-  - DynamoDB encryption at rest (AWS managed keys)
-- **Video Retention**: Automatic deletion after 1 day via S3 lifecycle policies
-- **Access Control**: Amazon Cognito User Pool 認証（PKCE Authorization Code Flow + CognitoUserPoolsAuthorizer で全 API 保護）
-- **Network Security**:
-  - HTTPS enforcement via CloudFront
-  - API Gateway with Cognito Authorizer（4XX レスポンスにも CORS ヘッダー付与）
-  - IoT Core certificate-based authentication
-
-## Project Status
-
-For current implementation status and next steps, see:
-- [Implementation Tasks](.kiro/specs/tasks.md) - Detailed task list with progress tracking
-
-## Documentation
-
-### Quick Links
-- **[Installation Guide](docs/INSTALLATION.md)** - システムのインストール手順
-- **[User Manual](docs/USER_MANUAL.md)** - ユーザーマニュアル
-- **[Docker Development Guide](docs/guides/DOCKER_DEVELOPMENT_GUIDE.md)** - Docker開発環境のセットアップ
-
-### Specifications
-- [Requirements Document](.kiro/specs/requirements.md)
-- [Design Document](.kiro/specs/design.md)
-- [Implementation Tasks](.kiro/specs/tasks.md)
+開発ガイドライン: [.kiro/steering/](.kiro/steering/) 配下


### PR DESCRIPTION
Closes #18

## Summary
- CLAUDE.md を「目次（TOC）」スタイルに再構成（125 → 93 行）。冒頭に「作業開始前のチェック」セクションを追加し、複数 AI / 開発者の並行作業を想定したルール再参照を促す
- README.md を OSS ユーザー・開発者向けの概要中心に再構成（492 → 219 行）。CDK / Colima / Edge 等の開発内部詳細は steering / edge/README へ追い出し
- steering/architecture.md に Edge コンポーネントと MQTT パイプラインの詳細セクションを追加（+66 行）。CLAUDE.md から削った Edge 詳細をここに集約し情報損失を回避

## ドキュメント役割の整理（本 PR で明確化）

| ファイル | 役割 | 想定読者 |
|---|---|---|
| **CLAUDE.md** | 開発時の TOC | AI エージェント・開発者（毎回参照） |
| **README.md** | プロダクト概要 | OSS ユーザー・新規開発者（一度読む） |
| **.kiro/steering/*.md** | 詳細・権威ある仕様 | AI エージェント・開発者（実装中の参照） |
| **.kiro/specs/*.md** | 要件・設計・タスク | 仕様駆動開発全般 |
| **edge/README.md** | Edge 運用ガイド | RPi/Mac でのセットアップ・トラブル時 |

## 参考スタイル
- CLAUDE.md: https://github.com/ikeom-je/image-composite-agent/blob/dev/CLAUDE.md
- README.md: https://github.com/ikeom-je/image-composite-agent/blob/dev/README.md
- 絵文字見出しは本プロジェクトでは使用しない（ユーザー指示）

## 検証
- すべての相互リンク 22 件が到達可能（specs / steering / docs / edge）
- 既存テスト・ビルドへの影響なし（ドキュメントのみ変更）

## Test plan
- [x] CLAUDE.md と README.md のリンク到達性確認
- [x] steering/architecture.md の追加セクションが既存構造と整合
- [ ] レビュー後 dev へマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)